### PR TITLE
add logging shutdown

### DIFF
--- a/src/llamator/main.py
+++ b/src/llamator/main.py
@@ -198,3 +198,4 @@ def start_testing(
         )
 
     print(f"{BRIGHT}{colorama.Fore.CYAN}Thank you for using LLAMATOR!{RESET}")
+    logging.shutdown()


### PR DESCRIPTION
Когда завершается работа LLaMator'а, файл с логами оказывается по-прежнему заблокирован в Jupyter notebook. Предлагаю добавить вот эту строчку. При повторном запуске функции старта тестирования логи корректно пишутся в новый файл.