### PR TITLE
add fitting datasets to `num_attempts`

### DIFF
--- a/src/llamator/attacks/base64_injection.py
+++ b/src/llamator/attacks/base64_injection.py
@@ -83,11 +83,14 @@ class TestBase64Injection(TestBase):
         data = pd.read_parquet(dataset_filename, engine="fastparquet")
         rows_count = data.shape[0]
 
-        if rows_count > self.num_attempts:
+        if self.num_attempts <= rows_count:
             # If dataset is larger than requested number of attack samples, reduce dataset by taking attack_prompts_count samples
             data = data.sample(
                 n=self.num_attempts, random_state=42
             )  # constant 'random_state' for better reproducibility
+        else:
+            # If dataset is smaller than requested number of attack samples, fit the dataset repeating until num_attempts is reached
+            data = pd.concat([data] * (self.num_attempts // len(data) + 1))[:self.num_attempts].sort_index().reset_index(drop=True)
 
         # Generate list of attack prompt variations
         yield StatusUpdate(self.client_config, self.test_name, self.status, "Working", 0, self.num_attempts)

--- a/src/llamator/attacks/dan.py
+++ b/src/llamator/attacks/dan.py
@@ -64,11 +64,14 @@ class TestDAN(TestBase):
         data = pd.read_parquet(dataset_filename, engine="fastparquet")
         rows_count = data.shape[0]
 
-        if rows_count > self.num_attempts:
+        if self.num_attempts <= rows_count:
             # If dataset is larger than requested number of samples, reduce dataset by taking num_attempts samples
             data = data.sample(
                 n=self.num_attempts, random_state=42
             )  # constant `random_state` for better reproducibility
+        else:
+            # If dataset is smaller than requested number of attack samples, fit the dataset repeating until num_attempts is reached
+            data = pd.concat([data] * (self.num_attempts // len(data) + 1))[:self.num_attempts].sort_index().reset_index(drop=True)
 
         # Generate list of DAN (do anything now) attack prompt variations
         yield StatusUpdate(

--- a/src/llamator/attacks/ethical_compliance.py
+++ b/src/llamator/attacks/ethical_compliance.py
@@ -101,11 +101,14 @@ class TestEthicalCompliance(TestBase):
         data = pd.read_parquet(dataset_filename, engine="fastparquet")
         rows_count = data.shape[0]
 
-        if rows_count > self.num_attempts:
+        if self.num_attempts <= rows_count:
             # If dataset is larger than requested number of samples, reduce dataset by taking num_attempts samples
             data = data.sample(
                 n=self.num_attempts, random_state=42
             )  # constant `random_state` for better reproducibility
+        else:
+            # If dataset is smaller than requested number of attack samples, fit the dataset repeating until num_attempts is reached
+            data = pd.concat([data] * (self.num_attempts // len(data) + 1))[:self.num_attempts].sort_index().reset_index(drop=True)
 
         chat = ChatSession(self.attack_config.attack_client.get_target_client())
         for attack_prompt_index, row in data.iterrows():

--- a/src/llamator/attacks/past_tense.py
+++ b/src/llamator/attacks/past_tense.py
@@ -60,11 +60,14 @@ class TestPastTense(TestBase):
         data = pd.read_parquet(dataset_filename, engine="fastparquet")
         rows_count = data.shape[0]
 
-        if rows_count > self.num_attempts:
+        if self.num_attempts <= rows_count:
             # If dataset is larger than requested number of samples, reduce dataset by taking num_attempts samples
             data = data.sample(
                 n=self.num_attempts, random_state=42
             )  # constant `random_state` for better reproducibility
+        else:
+            # If dataset is smaller than requested number of attack samples, fit the dataset repeating until num_attempts is reached
+            data = pd.concat([data] * (self.num_attempts // len(data) + 1))[:self.num_attempts].sort_index().reset_index(drop=True)
 
         # Lists to store prompts, responses, and statuses for report generation
         attack_prompts = []

--- a/src/llamator/attacks/ru_dan.py
+++ b/src/llamator/attacks/ru_dan.py
@@ -64,11 +64,14 @@ class TestRuDAN(TestBase):
         data = pd.read_parquet(dataset_filename, engine="fastparquet")
         rows_count = data.shape[0]
 
-        if rows_count > self.num_attempts:
+        if self.num_attempts <= rows_count:
             # If dataset is larger than requested number of samples, reduce dataset by taking num_attempts samples
             data = data.sample(
                 n=self.num_attempts, random_state=42
             )  # constant `random_state` for better reproducibility
+        else:
+            # If dataset is smaller than requested number of attack samples, fit the dataset repeating until num_attempts is reached
+            data = pd.concat([data] * (self.num_attempts // len(data) + 1))[:self.num_attempts].sort_index().reset_index(drop=True)
 
         # Generate list of DAN (do anything now) attack prompt variations
         yield StatusUpdate(

--- a/src/llamator/attacks/ru_ucar.py
+++ b/src/llamator/attacks/ru_ucar.py
@@ -65,11 +65,14 @@ class TestRuUCAR(TestBase):
         data = pd.read_parquet(dataset_filename, engine="fastparquet")
         rows_count = data.shape[0]
 
-        if rows_count > self.num_attempts:
+        if self.num_attempts <= rows_count:
             # If dataset is larger than requested number of samples, reduce dataset by taking num_attempts samples
             data = data.sample(
                 n=self.num_attempts, random_state=42
             )  # constant `random_state` for better reproducibility
+        else:
+            # If dataset is smaller than requested number of attack samples, fit the dataset repeating until num_attempts is reached
+            data = pd.concat([data] * (self.num_attempts // len(data) + 1))[:self.num_attempts].sort_index().reset_index(drop=True)
 
         # Generate list of attack prompt variations
         yield StatusUpdate(

--- a/src/llamator/attacks/ucar.py
+++ b/src/llamator/attacks/ucar.py
@@ -68,11 +68,14 @@ class TestUCAR(TestBase):
         data = pd.read_parquet(dataset_filename, engine="fastparquet")
         rows_count = data.shape[0]
 
-        if rows_count > self.num_attempts:
+        if self.num_attempts <= rows_count:
             # If dataset is larger than requested number of samples, reduce dataset by taking num_attempts samples
             data = data.sample(
                 n=self.num_attempts, random_state=42
             )  # constant `random_state` for better reproducibility
+        else:
+            # If dataset is smaller than requested number of attack samples, fit the dataset repeating until num_attempts is reached
+            data = pd.concat([data] * (self.num_attempts // len(data) + 1))[:self.num_attempts].sort_index().reset_index(drop=True)
 
         # Generate list of attack prompt variations
         yield StatusUpdate(


### PR DESCRIPTION
Сделал так, чтобы количество атакующих промтов в ряде атак было равно количеству попыток проведения атаки, запрошенному пользователем. На случай, если пользователь захочет, чтобы каждый атакующий запрос из датасета прогнался по несколько раз